### PR TITLE
#31 Feat: 예매하기 페이지 및 Navbar 디자인 수정

### DIFF
--- a/homepage/src/app/components/Navbar.tsx
+++ b/homepage/src/app/components/Navbar.tsx
@@ -41,42 +41,40 @@ let Links =[
 return (
     <nav className="w-[full] h-[104px] flex relative bg-[white] z-50 font-['pretendard']">
         <NavBg>
-        <div className="lg:flex">
+        <div className="lg:flex ">
             <div className="flex justify-between">
                 <Link href="/" key="home">
-                    <Image src="/assets/images/layout/Logo.svg" alt="Logo" width={165} height={30} onClick={showMenu?toggleMenu:undefined} className= "ml-[20px] lg:ml-[12.5vw] w-[165px] h-[30px] max-w-[165px] max-h-[30px]" priority/>
+                    <Image src="/assets/images/layout/Logo.svg" alt="Logo" width={165} height={30} onClick={showMenu?toggleMenu:undefined} className= "ml-[20px] lg:ml-[12.5vw] w-[165px] lg:w-[12.5vw] h-[30px] lg:max-w-[10vw]  max-w-[165px] max-h-[30px]" priority/>
                 </Link>
                 <div className="lg:hidden">
                     <button className="px-2 outline-none" onClick={toggleMenu}>
-                    {showMenu ? (<Image src="assets/images/layout/close.svg" width={32} height={32} alt="logo" /> ) : ( <Image src="assets/images/layout/hamburger.svg" width={32} height={32} alt="logo" className="focus:border-none active:border-none" />)}
+                    {showMenu ? (<Image src="/assets/images/layout/close.svg" width={32} height={32} alt="close" /> ) : ( <Image src="/assets/images/layout/hamburger.svg" width={32} height={32} alt="hamburger" className="focus:border-none active:border-none" />)}
                     </button>
                 </div>
             </div>
-            <div className={`${ showMenu ? "flex flex-col absolute mt-[20px] bg-[white] " : "hidden flex-row lg:pl-[2.6vw]" } lg:flex w-full items-center`}>
-                <ul className={`${ showMenu ? "flex-col py-[40px] mt-12 mb-4 ": "lg:gap-[7vw] flex-col lg:flex lg:flex-row"}`}>
+            <div className={`${ showMenu ? "flex flex-col absolute mt-[20px] bg-[white] " : "hidden flex-row ml-0 lg:mr-[12.5vw]" } lg:flex w-full items-center`}>
+                <ul className={`${ showMenu ? "flex-col py-[40px] mt-12 mb-4 ": " lg:w-[50vw] flex-col lg:flex lg:flex-row"}`}>
                     { Links.map((link) => (
                         <Link key={link.name} href={link.link} onClick={() => setFocusedLink(link.name)}>
-                            <div className={`${ focusedLink === link.name || pathname?.startsWith(link.link)
-                                    ? showMenu
+                            <div className={`${ showMenu
                                         ? "font-[700]"
-                                        : "= border-t-4 flex items-center justify-center border-t-[#281CFF]"
-                                    : ""
+                                        : "flex items-center justify-center w-[12.5vw]"
                                 }`}>
-                                <li key={link.name} onClick={showMenu ? toggleMenu : undefined} className={` text-[#000] text-center ${ showMenu ? "text-[20px] w-[100%] h-[100%] mb-4":"text-[16px] w-[80px] h-[32px] font-[600] leading-[19px] flex-shrink-0 flex justify-center items-center"}`}>
+                                <li key={link.name} onClick={showMenu ? toggleMenu : undefined} className={` text-[#000] ${ focusedLink === link.name || pathname?.startsWith(link.link) ? "border-t-4 border-t-[#281CFF]" : ""}  ${ showMenu ? "text-[20px] w-[100%] h-[100%] mb-4 text-center":"text-[16px] w-[80px]  h-[32px] font-[600] leading-[19px] flex-shrink-0 flex items-center justify-center"}`}>
                                 {link.name}
                                 </li>
                             </div>
                         </Link>
                         ))}
                 </ul>
-                <ul className={`${ showMenu ? " my-12 flex flex-row items-center justify-center mx-12":"hidden lg:flex flex-row ml-[5vw]"}`}>
-                    <div className={`${ showMenu ? "flex flex-row gap-[20px]" :"w-[12.5vw] flex items-center justify-between"}`}>
-                    <li className={`${ showMenu ? "w-[100%] h-[100%]" : "w-[100%] h-[100%] flex items-center justify-center"}`}>
+                <ul className={`${ showMenu ? " my-12 flex flex-row mx-12 items-center justify-center":"hidden lg:flex flex-row lg:w-[12.5vw] items-center justify-center lg:ml-[1.5vw]"}`}>
+                    <div className={`${ showMenu ? "flex flex-row gap-[20px]" :"w-[12.5vw] flex items-center mx-auto"}`}>
+                    <li className={`${ showMenu ? "w-[100%] h-[100%]" : "w-[4vw] h-[100%] flex items-center justify-center"}`}>
                     <Link href="http://pf.kakao.com/_UaIZG" target='_blank' passHref>
                         <Image src="/assets/images/layout/kakaotalk.svg" alt="카카오톡 채널" width={100} height={100} className="w-[28px] h-[28px]"/>
                     </Link>
                     </li>
-                    <li className={`${ showMenu ? "w-[100%] h-[100%] " : "w-[100%] h-[100%] flex items-center justify-center"}`}>
+                    <li className={`${ showMenu ? "w-[100%] h-[100%] " : "w-[4vw] h-[100%] flex items-center justify-center"}`}>
                     <Link
                         href="https://instagram.com/kahlua_band_?igshid=MzRlODBiNWFlZA=="
                         target='_blank'
@@ -85,7 +83,7 @@ return (
                         <Image src="/assets/images/layout/instagram.svg" alt="인스타그램" width={100} height={100} className="w-[28px] h-[28px]" />
                     </Link>
                     </li>
-                    <li className={`${ showMenu ? "w-[100%] h-[100%] " : "w-[100%] h-[100%] flex items-center justify-center"}`}>
+                    <li className={`${ showMenu ? "w-[100%] h-[100%] " : "w-[4vw] h-[100%] flex items-center justify-center"}`}>
                     <Link href="https://www.youtube.com/@kahluaband8409" target='_blank' passHref>
                         <Image src="/assets/images/layout/youtube.svg" alt="유튜브" width={100} height={100} className="w-[28px] h-[28px]" />
                     </Link>

--- a/homepage/src/pages/tickets/Calendar.tsx
+++ b/homepage/src/pages/tickets/Calendar.tsx
@@ -44,7 +44,7 @@ return (
             <div className="flex font-[400] text-[12px] mx-auto my-auto ">
                 {dayNames.map((dayName) => (
                 <div key={dayName} className="mx-auto w-[20px] h-[20px] flex-shrink-0 mb-[4px] ">
-                    <div className="w-[20px] h-[20px] text-[4px] font-[500] flex items-center justify-center">
+                    <div className={`${dayName === "Sun" ? "text-[red]" : ""} ${dayName==="Sat" ? "text-[blue]":""} w-[20px] h-[20px] text-[12px] font-[500] flex items-center justify-center`}>
                     {dayName}
                     </div>
                 </div>

--- a/homepage/src/pages/tickets/Modal.tsx
+++ b/homepage/src/pages/tickets/Modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 
 interface Order {
@@ -13,36 +13,57 @@ const Modal = () => {
     const [searchResult, setSearchResult] = useState<Order[]>([]);
     const [searched, setSearched] = useState(false);
     const [validOrderNumber, setValidOrderNumber] = useState(true);
-
-    const handleSearch = () => {
-        const tempSearchResult = [
-            { id: 1, orderNumber: "123456", name: "서지현", cancelable: true },
-            { id: 2, orderNumber: "789012", name: "임가은", cancelable: false },
-        ];
-
-        const filteredSearchResult = tempSearchResult.filter(order => order.orderNumber === orderNumber);
-        if (filteredSearchResult.length > 0) {
-            setSearchResult(filteredSearchResult);
-            setSearched(true);
-        } else {
-            setSearched(false);
-            setValidOrderNumber(false);
-        }
-    };
-
-
     const [isClose, setIsClose] = useState(false);
 
+    const handleSearch = () => {
+        const tempSearchResult: Order[] = [
+        { id: 1, orderNumber: "123456", name: "서지현", cancelable: true },
+        { id: 2, orderNumber: "789012", name: "임가은", cancelable: false },
+        ];
+    
+        const filteredSearchResult = tempSearchResult.filter(
+        (order) => order.orderNumber === orderNumber
+        );
+        if (filteredSearchResult.length > 0) {
+        setSearchResult(filteredSearchResult);
+        setSearched(true);
+        setValidOrderNumber(true);
+        } else {
+        setSearched(false);
+        setValidOrderNumber(false);
+        }
+    };
+    
+    const handleInputKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+        handleSearch();
+        }
+    };
+    
     const handleIsClose = () => {
         setIsClose(true);
     };
-
-    const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    
+    const handleOverlayClick = (
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>
+    ) => {
         if (event.target === event.currentTarget) {
         handleIsClose();
         }
     };
-
+    
+    const handleKeyPress = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+        handleIsClose();
+        }
+    };
+    
+    useEffect(() => {
+        document.addEventListener("keydown", handleKeyPress);
+        return () => {
+        document.removeEventListener("keydown", handleKeyPress);
+        };
+    }, []);
     return !isClose ? (
         <div onClick={handleOverlayClick} className= "fixed z-50 top-0 left-0 right-0 bottom-0 bg-[#0000008a] flex justify-center items-center">
             <div className="font-['pretendard'] w-[580px] h-[592px] bg-[#FFF] flex-shrink-0 fixed border-[#000] border-solid border-[1px] z-20">
@@ -60,6 +81,7 @@ const Modal = () => {
                         onChange={(e) => setOrderNumber(e.target.value)}
                         placeholder="예매번호를 입력해 주세요."
                         className="flex-grow px-[16px] outline-none text-[14px]"
+                        onKeyDown={handleInputKeyPress}
                     />
                     <div onClick={handleSearch} className="relative bg-[#D9D9D9] rounded-[4px] w-[24px] h-[24px] my-[12px] mr-[16px] cursor-pointer">
                         <Image src="/assets/images/tickets/search.png" alt="돋보기" width={100} height={100} className="flex w-[16px] h-[16px] mx-auto mt-[5px] "/>

--- a/homepage/src/pages/tickets/Modal.tsx
+++ b/homepage/src/pages/tickets/Modal.tsx
@@ -66,7 +66,7 @@ const Modal = () => {
     }, []);
     return !isClose ? (
         <div onClick={handleOverlayClick} className= "fixed z-50 top-0 left-0 right-0 bottom-0 bg-[#0000008a] flex justify-center items-center">
-            <div className="font-['pretendard'] w-[580px] h-[592px] bg-[#FFF] flex-shrink-0 fixed border-[#000] border-solid border-[1px] z-20">
+            <div className="font-['pretendard'] w-[580px] h-[592px] bg-[#FFF] flex-shrink-0 fixed z-20">
                 <button onClick={handleIsClose} className="ml-[544px] w-[36px] h-[38px] flex-col items-center flex justify-center text-[20px] font-[700]">x</button>
                 <div className="w-[100%] h-[1px] bg-[#D3D3D3]"/>
                 <div className="flex flex-col items-center text-center content-center mt-[40px] leading-normal">

--- a/homepage/src/pages/tickets/freshman_ticket.tsx
+++ b/homepage/src/pages/tickets/freshman_ticket.tsx
@@ -16,130 +16,173 @@ export default function freshman_ticket(){
 
     const [isCheck, setIsCheck] = useState(true);
     const [isPick, setIsPick] = useState("참");
+    const [payment, setPayment] = useState("계좌이체");
 
     const handleCheckboxChange1 = (event: any) => {
-    setIsCheck(event.target.value === "true");
+        setIsCheck(event.target.value === "true");
     };
 
     const handleCheckboxChange2 = (event: any) => {
-    setIsPick(event.target.value);
+        setIsPick(event.target.value);
     };
+
+    const handleCheckboxChange3 = (event: any) => {
+        setPayment(event.target.value);
+        };
+        
+    const handlePhoneNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const phoneNumber = event.target.value.replace(/[^0-9]/g, ''); // 숫자 이외의 문자 제거
+        event.target.value = phoneNumber;
+    };
+        
     return (
-        <div className="h-[1600px]">
+        <div className="h-[1800px] lg:h-[1700px]">
             <Background>
-                <div className="font-['pretendard'] mx-auto flex items-center flex-col mb-[84px]">
-            <div className="flex flex-col items-center justify-center text-center mt-[40px]">
-                <Image src="/assets/images/tickets/divider_medium.svg" alt="티켓" width={75} height={17}/>
-                <div className="mt-[16px] flex flex-row">
-                    <div className="font-[700] text-[32px] leading-[42px] text-[#281CFF]">신입생 티켓</div>
-                    <div className="font-[700] text-[32px] leading-[42px]">&nbsp;결제하기</div>
-                </div>
-                <div className="mt-[32px]">
-                    <div className="font-[500] text-[14px] leading-[21px]">깔루아 2023 9월 정기공연</div>
-                    <div className="font-[500] text-[14px] leading-[21px]">2023.09.01 오후 6시</div>
-                </div>
-            </div>
-            <div className="mt-[64px] flex flex-col ">
-                <div className="font-[700] ml-[0.5vw] text-[20px] leading-[30px]">예매 인원을 선택해주세요. </div>
-                <div className="w-[1108px] h-[3px] mt-[16px] bg-[#000] flex mx-auto"/>
-                <div className="ml-[0.5vw] ">
-                    <div className="mt-[32px] flex flex-row">
-                        <div className="text-[14px] font-[500] leading-[21px] text-[#6A6A6A]">신입생</div>
-                        <div className="ml-[60px] text-[14px] font-[500] leading-[21px] text-[#2D2D2D]">신입생 티켓은 1인 1매만 예매 가능합니다.</div>
+                <div className="font-['pretendard'] mx-[12.5vw] flex items-center flex-col mb-[84px]">
+                <div className="flex flex-col items-center mx-[12.5vw] text-center mt-[40px]">
+                    <Image src="/assets/images/tickets/divider_medium.svg" alt="티켓" width={75} height={17}/>
+                    <div className="mt-[16px] flex flex-row">
+                        <div className="font-[700] text-[32px] leading-[42px] whitespace-nowrap text-[#281CFF]">신입생 티켓</div>
+                        <div className="font-[700] text-[32px] leading-[42px] whitespace-nowrap">&nbsp;결제하기</div>
                     </div>
-                    <div className="mt-[16px] relative flex flex-row">
-                        <div className="flex flex-row">
-                            <div className="w-[120px] h-[76px] flex flex-col justify-center flex-shrink-0 text-[24px] font-[700] text-[#939393]">5000원</div>
-                            <div className="flex flex-col  justify-center flex-shrink-0 text-[24px] leading-[28px] font-[700] text-[#281CFF]">0원</div>
-                        </div>
-                        <div className="absolute left-0 top-7">
-                            <Image src="/assets/images/tickets/Arrow.svg" alt="arrow" width={100} height={100} className="w-[auto] h-[auto]"/>
-                        </div>
-                        <div className="w-[110px] h-[35px] mt-[20px] ml-[50px] flex flex-shrink-0 border border-solid border-[#D9D9D9] rounded-[10px] items-center justify-center">
-                            <div className="flex gap-4">
-                                <button className="flex h-[35px] mt-[2px] pr-[8px] text-center items-center justify-center border-r border-[#D9D9D9] text-[26px] font-[700]" onClick={handleDecrement}>-</button>
-                                <p className="text-[26px] font-[700]">{count}</p>
-                                <button className="flex h-[35px] mt-[2px] pl-[8px] text-center items-center justify-center border-l border-[#D9D9D9] text-[26px] font-[700]" onClick={handleIncrement}>+</button>
-                            </div>
-                        </div>
+                    <div className="mt-[32px]">
+                        <div className="font-[500] text-[14px] leading-[21px]">깔루아 2023 9월 정기공연</div>
+                        <div className="font-[500] text-[14px] leading-[21px]">2023.09.01 오후 6시</div>
                     </div>
                 </div>
-                <div className="w-[1108px] h-[3px] mt-[40px] bg-[#D3D3D3] flex mx-auto"/>
-                <div className="mx=auto ml-[0.5vw]">
-                    <div className="mt-[26px] flex flex-row">
-                        <div className="w-[140px] h-[24px] font-[700] pt-[6px] text-[20px] leading-[24px]">예매자 정보 입력</div>
-                        <div className="text-[14px] text-[#464646] pl-[56px] flex flex-col">
-                            <div>본인확인을 위해 정확한 정보를 입력해주세요.</div>
+                <div className="mt-[64px] flex flex-col mx-auto ">
+                    <div className="font-[700] text-[20px] leading-[30px]">예매 인원을 선택해주세요. </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[16px] bg-[#000] flex "/>
+                    <div className="ml-[0.5vw] ">
+                        <div className="mt-[32px] flex flex-row">
+                            <div className="text-[14px] font-[500] leading-[21px] text-[#6A6A6A]">신입생</div>
+                            <div className="ml-[5vw] text-[14px] font-[500] w-[60vw] leading-[21px] text-[#2D2D2D]">신입생 티켓은 1인 1매만 예매 가능합니다.</div>
+                        </div>
+                        <div className="mt-[16px] relative flex flex-row">
                             <div className="flex flex-row">
-                                홍익대 <p className="text-[#281CFF]">&nbsp;신입생 확인</p>을 위해 <p className="text-[#281CFF]">&nbsp;학과 및 학번 정보</p>를 작성해야 하는 점 양해 부탁드립니다. <p className="text-[#0047FF]">&nbsp;추후 공연장 입장 시 학생증 확인이 이루어질 수 있습니다.</p> 
+                                <div className="w-[120px] h-[76px] flex flex-col justify-center flex-shrink-0 text-[24px] font-[700] text-[#939393]">5000원</div>
+                                <div className="flex flex-col  justify-center flex-shrink-0 text-[24px] leading-[28px] font-[700] text-[#281CFF]">0원</div>
+                            </div>
+                            <div className="absolute left-0 top-7">
+                                <Image src="/assets/images/tickets/Arrow.svg" alt="arrow" width={100} height={100} className="w-[auto] h-[auto]"/>
+                            </div>
+                            <div className="bg-[white] w-[110px] h-[35px] mt-[20px] ml-[5vw] flex flex-shrink-0 border border-solid border-[#D9D9D9] rounded-[10px] items-center justify-center">
+                                <div className="flex gap-4">
+                                    <button className="flex h-[35px] mt-[2px] pr-[8px] text-center items-center justify-center border-r border-[#D9D9D9] text-[26px] font-[700]" onClick={handleDecrement}>-</button>
+                                    <p className="text-[26px] font-[700]">{count}</p>
+                                    <button className="flex h-[35px] mt-[2px] pl-[8px] text-center items-center justify-center border-l border-[#D9D9D9] text-[26px] font-[700]" onClick={handleIncrement}>+</button>
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <div className="mt-[16px] flex flex-row mx-auto">
-                        <div className="input-with-placeholder relative w-[540px] h-[80px] flex-shrink-0 border border-[#6A6A6A] border-solid rounded-[10px] p-4">
-                            <input type="text" placeholder="예매자 이름"/>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D3D3D3] flex"/>
+                    <div className="mx-auto ml-[0.5vw]">
+                        <div className="mt-[32px] flex lg:flex-row flex-col ">
+                            <div className="w-[140px] h-[29px] font-[700] pt-[8px] text-[20px] leading-[24px]">예매자 정보 입력</div>
+                            <div className="w-[60vw] h-[50px] lg:w-[60vw] text-[14px] text-[#464646] lg:ml-[2.5vw] ml-[0.5vw] flex flex-col lg:mt-0 mt-[15px] ">
+                                <div>본인확인을 위해 정확한 정보를 입력해주세요.</div>
+                                <div className="flex flex-row">
+                                    <div className="hidden lg:flex ">
+                                        <p>홍익대</p><p className="text-[#281CFF] flex flex-row">&nbsp;신입생 확인</p>을 위해 <p className="text-[#281CFF]">&nbsp;학과 및 학번 정보</p><p>를 작성해야 하는 점 양해 부탁드립니다.</p>
+                                    </div>
+                                    <p className="hidden lg:flex">&nbsp;</p>
+                                    <div className="text-[#0047FF] flex">추후 공연장 입장 시 학생증 확인이 이루어질 수 있습니다.</div> 
+                                </div>
+                            </div>
                         </div>
-                        <div className="input-with-placeholder relative w-[540px] h-[80px] flex-shrink-0 border border-[#6A6A6A]  border-solid rounded-[10px] p-4 ml-[32px]">
-                            <input type="text" placeholder="연락처"/>
+                        <div className="mt-[18px] flex flex-row mx-auto">
+                            <div className="text-[16px] leading-[26px] font-[500] items-center flex h-[40px] w-[7.5vw] min-w-[50px]">이름</div>
+                            <div className="input-with-placeholder relative w-[20vw] ml-[1vw] h-[40px] flex-shrink-0 border bg-[white] border-[#6A6A6A] border-solid rounded-[10px] px-2">
+                                <input type="text" placeholder=""/>
+                            </div>
+                            <div className="ml-[10vw] text-[16px] leading-[26px] font-[500] items-center flex  h-[40px] w-[7.5vw] min-w-[55px]">연락처</div>
+                            <div className="input-with-placeholder relative w-[20vw] ml-[1vw] h-[40px] flex-shrink-0 border bg-[white] border-[#6A6A6A] border-solid rounded-[10px] px-2">
+                                <input type="text" placeholder="‘-’없이 입력해주세요. 예) 01012345678" onChange={handlePhoneNumberChange}/>
+                            </div>
+                        </div>
+                        <div className="mt-[20px] flex flex-row">
+                        <div className="text-[16px] leading-[26px] font-[500] items-center flex  h-[40px] w-[7.5vw] min-w-[50px]">학과</div>
+                            <div className="input-with-placeholder relative w-[20vw] ml-[1vw] h-[40px] flex-shrink-0 border bg-[white] border-[#6A6A6A] border-solid rounded-[10px] px-2">
+                                <input type="text" placeholder=""/>
+                            </div>
+                            <div className="ml-[10vw]  text-[16px] leading-[26px] font-[500] items-center flex  h-[40px] w-[7.5vw] min-w-[55px]">학번</div>
+                            <div className="input-with-placeholder relative w-[20vw] ml-[1vw] h-[40px] flex-shrink-0 border bg-[white] border-[#6A6A6A] border-solid rounded-[10px] px-2">
+                                <input type="text" placeholder="예) C123456"/>
+                            </div>
                         </div>
                     </div>
-                    <div className="mt-[20px] flex flex-row">
-                        <div className="input-with-placeholder relative w-[540px] h-[80px] flex-shrink-0 border border-[#6A6A6A]  border-solid rounded-[10px] p-4">
-                            <input type="text" placeholder="학과"/>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D3D3D3]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="mt-[32px] flex lg:flex-row flex-col">
+                            <div className="w-[160px] h-[29px] font-[700] text-[20px] leading-[30px]">티켓수령방법 선택</div>
+                            <div className="whitespace-pre-wrap w-[47.5vw] h-[26px] lg:ml-[2.5vw] ml-[0.5vw] lg:mt-0 mt-[15px]  text-[14px] font-[500] leading-[21px] text-[#464646] flex-shrink-0 flex flex-col lg:flex-row">
+                                <p className="whitespace-nowrap">티켓현장수령은 예매가 완료되면 부여되는</p> 
+                                <div className="flex flex-row">
+                                    <p className="hidden lg:flex">&nbsp;</p><p className="text-[#281CFF] whitespace-nowrap">[예약번호]로 공연 당일 티켓을 수령하여 입장</p><p className="whitespace-nowrap">합니다.</p>
+                                </div>
+                            </div>
                         </div>
-                        <div className="input-with-placeholder relative w-[540px] h-[80px] flex-shrink-0 border border-[#6A6A6A]  border-solid rounded-[10px] p-4 ml-[32px]">
-                            <input type="text" placeholder="학번"/>
+                        <div className="text-[20px] mt-[18px]">
+                            <label className="flex flex-row">
+                                <div className="flex items-center justify-center mt-[20px]">
+                                    <input type="radio" name="현장수령" checked={isCheck} onChange={handleCheckboxChange1} className="mr-[18px] w-[18px] h-[18px] accent-[#281CFF] flex-shrink-0"/>
+                                    <div className="text-[20px] font-[500] leading-[30px]">현장수령</div>
+                                </div>
+                            </label>
                         </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D9D9D9]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="flex flex-col lg:flex-row">
+                            <div className="w-[200px] h-[29px] mt-[32px] font-[700] text-[20px] leading-[30px]">신입생 뒷풀이 참여 여부</div>
+                            <div className="w-[740px] h-[26px] lg:mt-[32px] mt-[15px] lg:ml-[56px] ml-[0.5vw] text-[14px] font-[500] leading-[21px] text-[#464646] flex-shrink-0 flex flex-row">
+                            신입생의 경우 랜덤으로 조가 배정되어 <div className="text-[#281CFF]">&nbsp;뒷풀이</div>가 있을 예정입니다.
+                            </div>
+                        </div>
+                        <div className="mt-[20px] text-[20px] flex flex-row">
+                            <label className="flex flex-row items-center justify-center ">
+                                <input type="radio" name="뒷풀이" value={"참"} checked={isPick === "참"}  onChange={handleCheckboxChange2} className="mr-[18px] accent-[#281CFF]  w-[18px] h-[18px] flex-shrink-0"/>
+                                <div className="font-[500]">참</div>
+                            </label>
+                            <label className="ml-[9.4vw] flex-row flex items-center justify-center ">
+                                <input type="radio" name="뒷풀이" value={"불참"} checked={isPick === "불참"} onChange={handleCheckboxChange2} className="mr-[18px] accent-[#281CFF]  w-[18px] h-[18px] flex-shrink-0"/>
+                                <div className="font-[500]">불참</div>
+                            </label>
+                        </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D9D9D9]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="flex flex-row">
+                            <div className="w-[200px] h-[29px] mt-[32px] font-[700] text-[20px] leading-[30px]">결제 방법 선택</div>
+                        </div>
+                        <div className="mt-[20px] text-[20px] flex flex-row">
+                            <label className="flex flex-row items-center justify-center ">
+                                <input type="radio" name="결제방법" value={"계좌이체"} checked={payment === "계좌이체"}  onChange={handleCheckboxChange3} className="mr-[18px] accent-[#281CFF]  w-[18px] h-[18px] flex-shrink-0"/>
+                                <div className="font-[500]">계좌이체</div>
+                            </label>
+                            <label className="ml-[118px] flex-row flex items-center justify-center ">
+                                <input type="radio" name="결제방법" value={"카카오페이"} checked={payment === "카카오페이"} onChange={handleCheckboxChange3} className="mr-[18px] accent-[#281CFF]  w-[18px] h-[18px] flex-shrink-0"/>
+                                <div className="font-[500]">카카오페이</div>
+                            </label>
+                        </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D3D3D3]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="mt-[10px] flex flex-row">
+                            <div className="w-[247px] h-[29px] pt-[32px] font-[700] text-[24px] leading-[28px]">유의사항 및 취소규정</div>
+                        </div>
+                        <ol className="list-decimal ml-[24px] font-[500] text-[13px] lg:text-[16px] mt-[44px] leading-[26px]">
+                            <li>예매취소는 24시간 이전에만 가능하며  그 이후에는 환불이 불가합니다. </li>
+                            <li>여러장을 구매했을 시에는 일괄취소만 가능합니다.</li>
+                            <li>예매하기-예매확인 - 예매취소 버튼으로 취소 가능합니다.</li>
+                            <li>공연 24시간 전 이후에 예매 확정 및 안내 문자 발송예정입니다.</li>
+                        </ol>
                     </div>
                 </div>
-                <div className="w-[1108px] h-[3px] mt-[40px] bg-[#D3D3D3] mx-auto"/>
-                <div className="ml-[0.5vw]">
-                    <div className="mt-[32px] flex flex-row">
-                        <div className="w-[160px] h-[29px] font-[700] text-[20px] leading-[30px]">티켓수령방법 선택</div>
-                        <div className="w-[740px] h-[26px] ml-[56px]  text-[14px] font-[500] leading-[21px] text-[#464646] flex-shrink-0 flex flex-row">
-                        티켓현장수령은 예매가 완료되면 부여되는 <div className="text-[#281CFF]">&nbsp;[예약번호]로 공연 당일 티켓을 수령하여 입장</div>합니다.
-                        </div>
-                    </div>
-                    <div className="mt-[20px] text-[20px]">
-                        <label className="flex flex-row">
-                            <input type="radio" name="현장수령" checked={isCheck} onChange={handleCheckboxChange1} className="mr-[18px] w-[30px] h-[30px] accent-[#281CFF] flex-shrink-0"/>
-                            <div className="text-[20px] font-[500] leading-[30px]">현장수령</div>
-                        </label>
-                    </div>
-                </div>
-                <div className="w-[1108px] h-[3px] mt-[41px] bg-[#D9D9D9]"/>
-                <div className="ml-[0.5vw]">
-                    <div className="flex flex-row">
-                        <div className="w-[200px] h-[29px] mt-[32px] font-[700] text-[20px] leading-[30px]">신입생 뒷풀이 참여 여부</div>
-                        <div className="w-[740px] h-[26px] mt-[32px]  ml-[56px] text-[14px] font-[500] leading-[21px] text-[#464646] flex-shrink-0 flex flex-row">
-                        홍익대학교 24학번 신입생의 경우 랜덤으로 조가 배정되어 <div className="text-[#281CFF]">&nbsp;뒷풀이</div>가 있을 예정입니다.
-                        </div>
-                    </div>
-                    <div className="mt-[20px] text-[20px] flex flex-row">
-                        <label className="flex flex-row">
-                            <input type="radio" name="뒷풀이" value={"참"} checked={isPick === "참"}  onChange={handleCheckboxChange2} className="mr-[18px] accent-[#281CFF]  w-[30px] h-[30px] flex-shrink-0"/>
-                            <div>참</div>
-                        </label>
-                        <label className="ml-[118px] flex flex-row">
-                            <input type="radio" name="뒷풀이" value={"불참"} checked={isPick === "불참"} onChange={handleCheckboxChange2} className="mr-[18px] accent-[#281CFF]  w-[30px] h-[30px] flex-shrink-0"/>
-                            <div>불참</div>
-                        </label>
-                    </div>
-                </div>
-                <div className="w-[1108px] h-[3px] mt-[40px] bg-[#D3D3D3]"/>
-                <div className="ml-[0.5vw]">
-                    <div className="mt-[10px] flex flex-row">
-                        <div className="w-[247px] h-[29px] pt-[32px] font-[700] text-[24px] leading-[28px]">유의사항 및 취소규정</div>
-                    </div>
-                    <ol className="list-decimal ml-[24px] font-[500] text-[16px] mt-[40px] leading-[26px]">
-                        <li>예매취소는 24시간 이전에만 가능하며  그 이후에는 환불이 불가합니다. </li>
-                        <li>여러장을 구매했을 시에는 일괄취소만 가능합니다.</li>
-                        <li>예매하기-예매확인 - 예매취소 버튼으로 취소 가능합니다.</li>
-                        <li>공연 24시간 전 이후에 예매 확정 및 안내 문자 발송예정입니다.</li>
-                    </ol>
+                <div className="flex items-center justify-center mt-[100px]">
+                    <button className="w-[270px] h-[52px] felx items-center justify-center rounded-[6px] bg-[#281CFF] text-[white]  text-18px] font-[700] leading-[17px] text-center">결제하기</button>
                 </div>
             </div>
-        </div>
         </Background>
         </div>
     );

--- a/homepage/src/pages/tickets/general_ticket.tsx
+++ b/homepage/src/pages/tickets/general_ticket.tsx
@@ -5,7 +5,6 @@ import Background from "@/app/components/Background";
 
 export default function general_ticket(){
     const [count, setCount] = useState(1);
-
     const handleIncrement = () => {
         setCount((prevCount) => (prevCount < 5 ? prevCount + 1 : prevCount)); //최대값을 1로 설정
     };
@@ -15,102 +14,153 @@ export default function general_ticket(){
     };
 
     const [isCheck, setIsCheck] = useState(true);
-    const [isPick, setIsPick] = useState("참");
+    const [payment, setPayment] = useState("계좌이체");
 
     const handleCheckboxChange1 = (event: any) => {
-    setIsCheck(event.target.value === "true");
+        setIsCheck(event.target.value === "true");
     };
 
     const handleCheckboxChange2 = (event: any) => {
-    setIsPick(event.target.value);
-    };
-    return (
-        <div className="h-[1800px]">
-        <Background>
-        <div className="font-['pretendard'] mt-[50px] mx-auto flex items-center flex-col mb-[84px]">
-            <div className="flex flex-col items-center justify-center text-center mt-[40px]">
-                <Image src="/ticket.png" alt="티켓" width={24} height={24}/>
-                <div className="mt-[20px] flex flex-row">
-                    <div className="font-[700] text-[24px] text-[#0047FF]">일반 티켓</div>
-                    <div className="font-[700] text-[24px]">&nbsp;결제하기</div>
-                </div>
-                <div className="mt-[20px]">
-                    <div className="font-[400] text-[20px]">깔루아 2023 9월 정기공연</div>
-                    <div className="font-[400] text-[20px]">2023.09.01 오후 6시</div>
-                </div>
-            </div>
-            <div className="mt-[55px] flex flex-col">
-                <div className="pl-[8px] font-[700] text-[24px]">예매 인원을 선택해주세요. </div>
-                <div className="w-[1120px] h-[3px] mt-[16px] bg-[#000]"/>
-                <div className="pl-[8px]">
-                    <div className="mt-[10px] flex flex-row">
-                        <div className="text-[14px] text-[#939393]">일반</div>
-                        <div className="ml-[16px] text-[14px] text-[#464646]">일반 티켓은 1인 5매까지 예매 가능합니다.</div>
-                    </div>
-                    <div className="mt-[4px] relative flex flex-row">
-                        <div className="flex flex-row">
-                            <div className="w-[156px] h-[76px] flex flex-col justify-center flex-shrink-0 text-[24px] font-[700] text-[#000000]">5000원</div> 
-                        </div>
-                        <div className="w-[140px] h-[40px] mt-[20px] ml-[200px] flex flex-shrink-0 border border-solid border-[#D9D9D9] rounded-[10px] items-center justify-center">
-                            <div className="flex gap-6">
-                                <button className="flex px-3 text-center items-center justify-center border-r border-[#D9D9D9] text-[26px] font-[700]" onClick={handleDecrement}>-</button>
-                                <p className="text-[26px] font-[700]">{count}</p>
-                                <button className="flex px-3 text-center items-center justify-center border-l border-[#D9D9D9] text-[26px] font-[700]" onClick={handleIncrement}>+</button>
+        setPayment(event.target.value);
+        };
+
+    const payer_info = () => {
+        const divs = [];
+        for (let i = 0; i < count; i++) {
+            divs.push(
+                <div key={i}>
+                    <div className="flex flex-row mt-[18px]">
+                        <div className="flex items-center justify-center text-center">{i+1}. </div>
+                        <div className=" flex flex-row ml-[1vw] lg:mx-auto">
+                            <div className="text-[16px] leading-[26px] font-[500] items-center flex h-[40px] w-[7.5vw] min-w-[50px]">이름</div>
+                            <div className="input-with-placeholder relative w-[20vw] ml-[0.5vw] h-[40px] flex-shrink-0 border bg-[white] border-[#6A6A6A] border-solid rounded-[10px] px-2">
+                                <input type="text" placeholder=""/>
+                            </div>
+                            <div className="ml-[6vw] lg:ml-[10vw] text-[16px] leading-[26px] font-[500] items-center flex  h-[40px] w-[7.5vw] min-w-[55px]">연락처</div>
+                            <div className="input-with-placeholder relative lg:w-[20vw] w-[22vw] ml-[0.5vw] h-[40px] flex-shrink-0 border bg-[white] border-[#6A6A6A] border-solid rounded-[10px] px-2">
+                                <input type="text" placeholder="‘-’없이 입력해주세요. 예) 01012345678"  onChange={handlePhoneNumberChange}/>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div className="w-[1120px] h-[3px] mt-[15px] bg-[#D9D9D9]"/>
-                <div className="pl-[8px]">
-                
-                    <div className="mt-[10px] flex flex-row">
-                        <div className="w-[247px] h-[29px] pt-[6px] font-[700] text-[24px]">예매자 정보 입력</div>
-                        <div className="mt-[12px] text-[14px] text-[#464646] flex flex-col">
-                            본인확인을 위해 정확한 정보를 입력해주세요.
-                        </div>
+            );
+        }
+        return divs;
+    };
+
+    const handlePhoneNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const phoneNumber = event.target.value.replace(/[^0-9]/g, ''); // 숫자 이외의 문자 제거
+        event.target.value = phoneNumber;
+    };
+        
+    return (
+        <div className="h-[1900px] lg:h-[1800px]">
+            <Background>
+                <div className="font-['pretendard'] mx-[12.5vw] flex items-center flex-col mb-[84px]">
+                <div className="flex flex-col items-center mx-[12.5vw] text-center mt-[40px]">
+                    <Image src="/assets/images/tickets/divider_medium.svg" alt="티켓" width={75} height={17}/>
+                    <div className="mt-[16px] flex flex-row">
+                        <div className="font-[700] text-[32px] leading-[42px] whitespace-nowrap text-[#281CFF]">일반 티켓</div>
+                        <div className="font-[700] text-[32px] leading-[42px] whitespace-nowrap">&nbsp;결제하기</div>
                     </div>
-                    {[...Array(count)].map((_, index) => (
-                    <div key={index}>
-                        <div className="mt-[33px] flex flex-row">
-                        <div className="input-with-placeholder relative w-[540px] h-[76px] flex-shrink-0 border border-[#464646] border-solid rounded-[10px] p-4">
-                            <input type="text" placeholder="예매자 이름" />
-                        </div>
-                        <div className="input-with-placeholder relative w-[540px] h-[76px] flex-shrink-0 border border-[#464646]  border-solid rounded-[10px] p-4 ml-[20px]">
-                            <input type="text" placeholder="연락처" />
-                        </div>
-                        </div>
-                    </div>
-                    ))}
-                </div>
-                <div className="w-[1120px] h-[3px] mt-[64px] bg-[#D9D9D9]"/>
-                <div className="pl-[8px]">
-                    <div className="mt-[10px] flex flex-row">
-                        <div className="w-[247px] h-[29px] pt-[6px] font-[700] text-[24px]">티켓수령방법 선택</div>
-                        <div className="w-[740px] h-[26px] pt-[10px] ml-[16px] text-[16px] text-[#464646] flex-shrink-0 flex flex-row">
-                        티켓현장수령은 예매가 완료되면 부여되는 <div className="text-[#0047FF]">&nbsp;“예약번호"로 공연 당일 티켓을 수령하여 입장</div>합니다.
-                        </div>
-                    </div>
-                    <div className="mt-[33px] text-[20px]">
-                        <label className="flex flex-row">
-                            <input type="radio" name="현장수령" checked={isCheck} onChange={handleCheckboxChange1} className="mr-[18px] w-[30px] h-[30px] flex-shrink-0"/>
-                            <div>현장수령</div>
-                        </label>
+                    <div className="mt-[32px]">
+                        <div className="font-[500] text-[14px] leading-[21px]">깔루아 2023 9월 정기공연</div>
+                        <div className="font-[500] text-[14px] leading-[21px]">2023.09.01 오후 6시</div>
                     </div>
                 </div>
-                <div className="w-[1120px] h-[3px] mt-[64px] bg-[#D9D9D9]"/>
-                <div className="pl-[8px]">
-                    <div className="mt-[10px] flex flex-row">
-                        <div className="w-[247px] h-[29px] pt-[6px] font-[700] text-[24px]">유의사항 및 취소규정</div>
+                <div className="mt-[64px] flex flex-col mx-auto ">
+                    <div className="font-[700] text-[20px] leading-[30px]">예매 인원을 선택해주세요. </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[16px] bg-[#000] flex "/>
+                    <div className="ml-[0.5vw] ">
+                        <div className="mt-[32px] flex flex-row">
+                            <div className="text-[14px] font-[500] leading-[21px] text-[#6A6A6A]">일반</div>
+                            <div className="ml-[5vw] text-[14px] font-[500] w-[60vw] leading-[21px] text-[#2D2D2D]">일반 티켓은 1인 5매까지 예매 가능합니다.</div>
                     </div>
-                    <ol className="list-decimal ml-[24px] font-[700] text-[20px] mt-[36px]">
-                        <li>예매취소는 24간 이전에만 가능하며  그 이후에는 환불이 불가합니다. </li>
-                        <li>여러장을 구매했을 시에는 일괄취소만 가능합니다.</li>
-                        <li>예매하기-예매확인 - 예매취소 버튼으로 취소 가능합니다.</li>
-                        <li>공연 24시간 전 이후에 예매 확정 및 안내 문자 발송예정입니다.</li>
-                    </ol>
+                    <div className="mt-[16px] relative flex flex-roww">
+                        <div className="flex flex-row">
+                            <div className="w-[120px] h-[76px] flex flex-col justify-center flex-shrink-0 text-[24px] font-[700] text-[#000000]">5000원</div> 
+                        </div>
+                        <div className="bg-[white] w-[110px] h-[35px] mt-[20px] ml-[7.5vw] flex flex-shrink-0 border border-solid border-[#D9D9D9] rounded-[10px] items-center justify-center">
+                                <div className="flex gap-4">
+                                    <button className="flex h-[35px] mt-[2px] pr-[8px] text-center items-center justify-center border-r border-[#D9D9D9] text-[26px] font-[700]" onClick={handleDecrement}>-</button>
+                                    <p className="text-[26px] font-[700]">{count}</p>
+                                    <button className="flex h-[35px] mt-[2px] pl-[8px] text-center items-center justify-center border-l border-[#D9D9D9] text-[26px] font-[700]" onClick={handleIncrement}>+</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D3D3D3] flex"/>
+                    <div className="mx-auto ml-[0.5vw]">
+                        <div className="mt-[32px] flex lg:flex-row flex-col ">
+                            <div className="w-[140px] h-[29px] font-[700] pt-[8px] text-[20px] leading-[24px]">예매자 정보 입력</div>
+                            <div className="w-[60vw] h-[40px] lg:w-[60vw] text-[14px] text-[#464646] lg:ml-[2.5vw] ml-[0.5vw] flex flex-col lg:mt-0 justify-center mt-[12px] ">
+                                <div>본인확인을 위해 정확한 정보를 입력해주세요.</div>
+                        </div>
+                    </div>
+                    {payer_info()}
+                </div>
+                <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D3D3D3]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="mt-[32px] flex lg:flex-row flex-col">
+                            <div className="w-[160px] h-[29px] font-[700] text-[20px] leading-[30px]">티켓수령방법 선택</div>
+                            <div className="whitespace-pre-wrap w-[47.5vw] h-[26px] lg:ml-[2.5vw] ml-[0.5vw] lg:mt-[4px] mt-[15px]  text-[14px] font-[500] leading-[21px] text-[#464646] flex-shrink-0 flex flex-col lg:flex-row">
+                                <p className="whitespace-nowrap">티켓현장수령은 예매가 완료되면 부여되는</p> 
+                                <div className="flex flex-row">
+                                    <p className="hidden lg:flex">&nbsp;</p><p className="text-[#281CFF] whitespace-nowrap">[예약번호]로 공연 당일 티켓을 수령하여 입장</p><p className="whitespace-nowrap">합니다.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="text-[20px] mt-[18px]">
+                            <label className="flex flex-row">
+                                <div className="flex items-center justify-center mt-[12px]">
+                                    <input type="radio" name="현장수령" checked={isCheck} onChange={handleCheckboxChange1} className="mr-[18px] w-[18px] h-[18px] accent-[#281CFF] flex-shrink-0"/>
+                                    <div className="text-[20px] font-[500] leading-[30px]">현장수령</div>
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D9D9D9]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="flex flex-row">
+                            <div className="w-[200px] h-[29px] mt-[32px] font-[700] text-[20px] leading-[30px]">결제 방법 선택</div>
+                        </div>
+                        <div className="mt-[20px] text-[20px] flex flex-row">
+                            <label className="flex flex-row items-center justify-center ">
+                                <input type="radio" name="결제방법" value={"계좌이체"} checked={payment === "계좌이체"}  onChange={handleCheckboxChange2} className="mr-[18px] accent-[#281CFF]  w-[18px] h-[18px] flex-shrink-0"/>
+                                <div className="font-[500]">계좌이체</div>
+                            </label>
+                            <label className="ml-[118px] flex-row flex items-center justify-center ">
+                                <input type="radio" name="결제방법" value={"카카오페이"} checked={payment === "카카오페이"} onChange={handleCheckboxChange2} className="mr-[18px] accent-[#281CFF]  w-[18px] h-[18px] flex-shrink-0"/>
+                                <div className="font-[500]">카카오페이</div>
+                            </label>
+                        </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D9D9D9]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="flex flex-row">
+                            <div className="w-[200px] h-[29px] mt-[32px] font-[700] text-[20px] leading-[30px]">최종 결제 금액</div>
+                        </div>
+                        <div className="font-[700] text-[24px] mt-[20px] flex flex-row">
+                            5000원 x {count}매 = <p className="text-[#281CFF]">&nbsp;{5000*count}원</p>
+                        </div>
+                    </div>
+                    <div className="w-[72.5vw] h-[3px] mt-[32px] bg-[#D3D3D3]"/>
+                    <div className="ml-[0.5vw]">
+                        <div className="mt-[10px] flex flex-row">
+                            <div className="w-[247px] h-[29px] pt-[32px] font-[700] text-[24px] leading-[28px]">유의사항 및 취소규정</div>
+                        </div>
+                        <ol className="list-decimal ml-[24px] font-[500] text-[13px] lg:text-[16px] mt-[44px] leading-[26px]">
+                            <li>예매취소는 24시간 이전에만 가능하며  그 이후에는 환불이 불가합니다. </li>
+                            <li>여러장을 구매했을 시에는 일괄취소만 가능합니다.</li>
+                            <li>예매하기-예매확인 - 예매취소 버튼으로 취소 가능합니다.</li>
+                            <li>공연 24시간 전 이후에 예매 확정 및 안내 문자 발송예정입니다.</li>
+                        </ol>
+                    </div>
+                </div>
+                <div className="flex items-center justify-center mt-[100px]">
+                    <button className="w-[270px] h-[52px] felx items-center justify-center rounded-[6px] bg-[#281CFF] text-[white]  text-18px] font-[700] leading-[17px] text-center">결제하기</button>
                 </div>
             </div>
-        </div>
         </Background>
         </div>
     );

--- a/homepage/src/pages/tickets/index.tsx
+++ b/homepage/src/pages/tickets/index.tsx
@@ -63,7 +63,7 @@ export default function Tickets() {
 
     function copyUrl() {
         navigator.clipboard.writeText(nowUrl).then(res => {
-        alert("주소가 복사되었습니다!");
+        alert("링크가 복사되었습니다!");
         });
     }
 
@@ -72,13 +72,13 @@ export default function Tickets() {
     };
 
     return (
-        <div className="h-[1200px] flex items-center justify-center z-0 ">
+        <div className="h-[1100px] flex items-center justify-center z-0 ">
         <Background>
                 <div className="font-['pretendard']  flex flex-col items-center justify-center mb-[84px]">
                     <div className=" mt-[35px] flex flex-row  mx-auto w-[1110px]">
                         <Image src={data[0].image} alt='포스터' width={324} height={460} className='max-w-[324px] max-h-[460px]' priority/>
                         <div className="w-[776px] h-[402px] ml-[46px] flex-shrink-0">
-                            <div className="w-[76px] h-[24px]  flex-shrink-0 rounded-[40px] bg-[#281CFF] text-[14px] font-[600] tracking-[0.2px] leading-[20px] text-[#FFF] pt-[2px] text-center ">예매가능</div>
+                            <div className="w-[76px] h-[24px] flex flex-shrink-0 justify-center rounded-[40px] bg-[#281CFF] text-[14px] font-[600] tracking-[0.2px] leading-[20px] text-[#FFF] pt-[2px] text-center ">예매가능</div>
                             <div className="flex flex-row">
                                 <div className="mt-[8px] flex flex-shrink-0 text-black font-[700] text-[32px] leading-[42px]">{data[0].title}</div>
                                 <div className="ml-[272px] flex mt-[19px]">
@@ -153,7 +153,7 @@ export default function Tickets() {
                                 </div>
                                 
                             </div>
-                            <div className="w-[369px] h-[260px] flex flex-col bg-[#F1F5FF] ">
+                            <div className="w-[368px] h-[260px] flex flex-col bg-[#F1F5FF] ">
                             <div className=" flex flex-col ml-[50px] mt-[30px] mr-[50px]">
                                         <div className="flex w-[260px] text-center flex-row justify-between">
                                             <div className="text-[14px] font-[600] leading-[19px] w-[80px] h-[19px]">홍익대 신입생</div>


### PR DESCRIPTION
1. Navbar 칸에 맞추어 간격 수정 -> 로고 크기 한번씩 봐주세요
<img width="1264" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/9d8b6704-d368-4624-890a-d480d277c28c">


2. 예매하기 페이지 디자인 수정
- 달력은 공연 해당 달로 고정
<img width="1277" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/153d1003-7f71-47b5-972e-19c83bc75e8c">


3. 신입생 예매 페이지 디자인 수정
- 결제 방법 선택 및 결제하기 버튼 생성
- 연락처 칸 숫자만 입력되도록 수정
<img width="1267" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/973495a3-70ac-499c-9bc4-566f661d6eff">
<img width="1279" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/ae6ddc18-6422-4ec1-ba25-8bca7b84f2e1">


4. 일반 예매 페이지 디자인 수정
- 결제 방법 선택 및 결제하기 버튼 생성
- 최종 결제 금액 표시
- 연락처 칸 숫자만 입력되도록 수정
<img width="1279" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/fd030209-573c-4069-a51a-8e9abcc3ca26">
<img width="1280" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/c7218117-ad56-4e2f-9728-8d7cd80a965f">


5. 예매내역 확인 모달창 수정
- 예매번호 입력 후 엔터키 누르면 검색 기능 추가
-  esc키 누르면 모달창 닫기 기능 추가
<img width="1258" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/40fb2dd8-2d24-480e-920f-fc9327e1f216">
<img width="1261" alt="image" src="https://github.com/kahluaband/Homepage_FE_20th/assets/109282927/5a9db35c-5319-41e5-a7c1-2dc49999b6ff">


